### PR TITLE
Formatting for .env files

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,13 @@ dependencies:
 
 Your `.env` file:
 ```
+# Comments can be included for context
+#
 MY_VARIABLE=my-value
+
+# Empty Lines are also ignore
+#
+ANOTHER_VAR=awesome-value
 ```
 
 In your application:
@@ -67,3 +73,4 @@ puts ENV["MY_VARIABLE"] # my-value
 
 - [[gdotdesign]](https://github.com/[gdotdesign]) Gusztáv Szikszai - creator, maintainer
 - [[bonyiii]](https://github.com/[bonyiii]) 
+- [[neovintage]](https://github.com/[neovintage]) Rimas Silkaitis

--- a/spec/dotenv_spec.cr
+++ b/spec/dotenv_spec.cr
@@ -25,6 +25,17 @@ describe Dotenv do
     File.delete ".test-env"
   end
 
+  context "Comment Lines and Empty Lines" do
+    File.write ".test-env", "# This is a comment\nVAR=Dude\n\n"
+
+    it "should ignore" do
+      hash = Dotenv.load ".test-env"
+      hash.should eq({ "VAR" => "Dude"})
+    end
+
+    File.delete ".test-env"
+  end
+
   context "From IO" do
     it "should load env" do
       io = MemoryIO.new "VAR2=test\nVAR3=other"

--- a/src/dotenv.cr
+++ b/src/dotenv.cr
@@ -51,8 +51,10 @@ module Dotenv
   end
 
   private def handle_line(line, hash)
-    name, value = line.split("=")
-    hash[name.strip] = value.strip
+    if line !~ /\A\s*(?:#.*)?\z/
+      name, value = line.split("=")
+      hash[name.strip] = value.strip
+    end
   rescue ex
     log "DOTENV - Malformed line #{line}"
   end


### PR DESCRIPTION
I needed more context when creating .env files. This allows the .env file to not throw errors when theres an empty line or the line starts with comment. Comment lines are prefaced w/ a `#`.

Inspiration taken from ruby project of same name. 