### PR TITLE
Allow `=` in ENV values

### DIFF
--- a/spec/dotenv_spec.cr
+++ b/spec/dotenv_spec.cr
@@ -36,6 +36,17 @@ describe Dotenv do
     File.delete ".test-env"
   end
 
+  context "Values with special characters" do
+    File.write ".test-env", "VAR=postgres://foo@localhost:5432/bar?max_pool_size=10"
+
+    it "should allow `=` in values" do
+      hash = Dotenv.load ".test-env"
+      hash.should eq({"VAR" => "postgres://foo@localhost:5432/bar?max_pool_size=10"})
+    end
+
+    File.delete ".test-env"
+  end
+
   context "From IO" do
     it "should load env" do
       io = IO::Memory.new "VAR2=test\nVAR3=other"

--- a/src/dotenv.cr
+++ b/src/dotenv.cr
@@ -51,7 +51,7 @@ module Dotenv
 
   private def handle_line(line, hash)
     if line !~ /\A\s*(?:#.*)?\z/m
-      name, value = line.split("=")
+      name, value = line.split("=", 2)
       hash[name.strip] = value.strip
     end
   rescue ex


### PR DESCRIPTION
Currently ENV values such as this one:

`postgres://foo@localhost:5432/bar?max_pool_size=10`

... are split up on `=` and wind up outputting: 

`postgres://foo@localhost:5432/bar?max_pool_size`

This PR corrects this behavior.

Thanks!