### PR TITLE
Use dedicated parser to parse each dotenv line

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To load a file named `.env-file`:
 ```crystal
 require "dotenv"
 
-The default file is ".env"
+# The default file is ".env"
 Dotenv.load ".env-file"
 ```
 


### PR DESCRIPTION
## Description

Using a dedicated parser to parse each dotenv line provides several benefits over a regex. I thought we would gain performance, but that's not the case. Maybe because the regex was simple, and the `pcre` C library is optimized.
Even if there are more lines of code, having a dedicated parser brings:
- custom exceptions for parsing errors
- easier to understand logic, even more true for more complex parsing.
- flexible logic modification

Even though I improved the deal with quotes, the parser is quite basic as for now. It doesn't handle escaped characters, I don't know if this is what we would want at the end.
It also only removes the last quote if there is no character after (as the current one).
For instance `"value" # comments` => `acd"`.
The only way to solve this is to create an intermediate array, because a whitespace or `#` can be inside the quotes, like `"value # test" # comments`.

## Benchmark

```cr
require "benchmark"
require "./cr-dotenv/src/dotenv.cr"
require "./cr-dotenv-old/src/dotenv.cr"

DOTENV = <<-E
# comments
VAR=value
STR="my words"

OTHER=abcde
E

Benchmark.ips do |bm|
  bm.report("new dotenv") do
    Dotenv.load_string DOTENV
  end

  bm.report("old dotenv") do
    DotenvOld.load_string DOTENV
  end
end
```

Result:
```
new dotenv 585.85k (  1.71µs) (± 5.19%)  1.87kB/op   1.02× slower
old dotenv 596.85k (  1.68µs) (± 4.91%)  0.99kB/op        fastest
```