### PR TITLE
Refactor skip_duplicate_keys feature

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: dotenv
-version: 0.3.1
+version: 0.4.0
 
 authors:
   - Gusztáv Szikszai <guszti5@hotmail.com>

--- a/spec/dotenv_spec.cr
+++ b/spec/dotenv_spec.cr
@@ -103,6 +103,12 @@ describe Dotenv do
       ENV["VAR1"].should eq "Hello"
       ENV["HELLO"]?.should be_nil
     end
+
+    it "loads a string, and overrides duplicate keys" do
+      ENV["VAR"] = "Hello"
+      Dotenv.load_string "VAR=World", skip_duplicate_keys: false
+      ENV["VAR"].should eq "World"
+    end
   end
 
   describe "#load?" do
@@ -110,10 +116,21 @@ describe Dotenv do
       Dotenv.load?(".some-non-existent-env-file").should be_nil
     end
 
-    it "loads environment variables" do
+    it "loads environment variables from a file" do
       tempfile = File.tempfile "dotenv", &.print("VAR=Hello")
       begin
         Dotenv.load? tempfile.path
+        ENV["VAR"].should eq "Hello"
+      ensure
+        tempfile.delete
+      end
+    end
+
+    it "loads environment variables from a file, and overrides duplicate keys" do
+      tempfile = File.tempfile "dotenv", &.print("VAR=Hello")
+      begin
+        ENV["VAR"] = "World"
+        Dotenv.load? tempfile.path, skip_duplicate_keys: false
         ENV["VAR"].should eq "Hello"
       ensure
         tempfile.delete
@@ -138,6 +155,17 @@ describe Dotenv do
           tempfile.delete
         end
       end
+
+      it "loads environment variables, and overrides duplicate keys" do
+        tempfile = File.tempfile "dotenv", &.print("VAR=Hello")
+        begin
+          ENV["VAR"] = "World"
+          Dotenv.load tempfile.path, skip_duplicate_keys: false
+          ENV["VAR"].should eq "Hello"
+        ensure
+          tempfile.delete
+        end
+      end
     end
 
     context "From IO" do
@@ -149,6 +177,17 @@ describe Dotenv do
         ENV["VAR2"].should eq "test"
         ENV["VAR3"].should eq "other"
       end
+
+      it "loads environment variables, and overrides duplicate keys" do
+        io1 = IO::Memory.new "VAR2=test\nVAR3=other"
+        io2 = IO::Memory.new "VAR2=other\nVAR3=test"
+        Dotenv.load io1
+        ENV["VAR2"].should eq "test"
+        ENV["VAR3"].should eq "other"
+        Dotenv.load io2, skip_duplicate_keys: false
+        ENV["VAR2"].should eq "other"
+        ENV["VAR3"].should eq "test"
+      end
     end
 
     context "From Hash" do
@@ -157,44 +196,11 @@ describe Dotenv do
         hash["test"].should eq "test"
         ENV["test"].should eq "test"
       end
-    end
-  end
 
-  describe "#load!" do
-    context "From file" do
-      it "loads environment variables, and overrides duplicate keys" do
-        dev_tempfile = File.tempfile "dotenv_dev", &.print("VAR=Hello")
-        test_tempfile = File.tempfile "dotenv_test", &.print("VAR=World")
-        begin
-          Dotenv.load dev_tempfile.path
-          ENV["VAR"].should eq "Hello"
-          Dotenv.load! test_tempfile.path
-          ENV["VAR"].should eq "World"
-        ensure
-          dev_tempfile.delete
-          test_tempfile.delete
-        end
-      end
-    end
-
-    context "From IO" do
-      it "loads environment variables, and overrides duplicate keys" do
-        io1 = IO::Memory.new "VAR2=test\nVAR3=other"
-        io2 = IO::Memory.new "VAR2=other\nVAR3=test"
-        Dotenv.load io1
-        ENV["VAR2"].should eq "test"
-        ENV["VAR3"].should eq "other"
-        Dotenv.load! io2
-        ENV["VAR2"].should eq "other"
-        ENV["VAR3"].should eq "test"
-      end
-    end
-
-    context "From Hash" do
       it "loads environment variables, and overrides duplicate keys" do
         Dotenv.load({"test" => "test"})
         ENV["test"].should eq "test"
-        Dotenv.load!({"test" => "updated"})
+        Dotenv.load({"test" => "updated"}, skip_duplicate_keys: false)
         ENV["test"].should eq "updated"
       end
     end

--- a/spec/dotenv_spec.cr
+++ b/spec/dotenv_spec.cr
@@ -106,7 +106,7 @@ describe Dotenv do
 
     it "loads a string, and overrides duplicate keys" do
       ENV["VAR"] = "Hello"
-      Dotenv.load_string "VAR=World", skip_duplicate_keys: false
+      Dotenv.load_string "VAR=World", override_keys: true
       ENV["VAR"].should eq "World"
     end
   end
@@ -130,7 +130,7 @@ describe Dotenv do
       tempfile = File.tempfile "dotenv", &.print("VAR=Hello")
       begin
         ENV["VAR"] = "World"
-        Dotenv.load? tempfile.path, skip_duplicate_keys: false
+        Dotenv.load? tempfile.path, override_keys: true
         ENV["VAR"].should eq "Hello"
       ensure
         tempfile.delete
@@ -160,7 +160,7 @@ describe Dotenv do
         tempfile = File.tempfile "dotenv", &.print("VAR=Hello")
         begin
           ENV["VAR"] = "World"
-          Dotenv.load tempfile.path, skip_duplicate_keys: false
+          Dotenv.load tempfile.path, override_keys: true
           ENV["VAR"].should eq "Hello"
         ensure
           tempfile.delete
@@ -184,7 +184,7 @@ describe Dotenv do
         Dotenv.load io1
         ENV["VAR2"].should eq "test"
         ENV["VAR3"].should eq "other"
-        Dotenv.load io2, skip_duplicate_keys: false
+        Dotenv.load io2, override_keys: true
         ENV["VAR2"].should eq "other"
         ENV["VAR3"].should eq "test"
       end
@@ -200,7 +200,7 @@ describe Dotenv do
       it "loads environment variables, and overrides duplicate keys" do
         Dotenv.load({"test" => "test"})
         ENV["test"].should eq "test"
-        Dotenv.load({"test" => "updated"}, skip_duplicate_keys: false)
+        Dotenv.load({"test" => "updated"}, override_keys: true)
         ENV["test"].should eq "updated"
       end
     end

--- a/src/dotenv.cr
+++ b/src/dotenv.cr
@@ -106,12 +106,12 @@ module Dotenv
   # hash = Dotenv.load_string "VAR=Hello"
   # hash # => {"VAR" => "Hello"}
   # ```
-  def load_string(env_vars : String, skip_duplicate_keys : Bool = true) : Hash(String, String)
+  def load_string(env_vars : String, override_keys : Bool = false) : Hash(String, String)
     hash = Hash(String, String).new
     env_vars.each_line do |line|
       handle_line line, hash
     end
-    load hash, skip_duplicate_keys
+    load hash, override_keys
   end
 
   # Loads environment variables from a file into the `ENV` constant
@@ -124,9 +124,9 @@ module Dotenv
   # Dotenv.load? ".env-file"    # => {"VAR" => "Hello"}
   # Dotenv.load? ".not-present" # => nil
   # ```
-  def load?(filename : Path | String = ".env", skip_duplicate_keys : Bool = true) : Hash(String, String)?
+  def load?(filename : Path | String = ".env", override_keys : Bool = false) : Hash(String, String)?
     if File.exists?(filename) || File.symlink?(filename)
-      load filename, skip_duplicate_keys
+      load filename, override_keys
     end
   end
 
@@ -139,12 +139,12 @@ module Dotenv
   # Dotenv.load ".env-file"    # => {"VAR" => "Hello"}
   # Dotenv.load ".absent-file" # => No such file or directory (Errno)
   # ```
-  def load(filename : Path | String = ".env", skip_duplicate_keys : Bool = true) : Hash(String, String)
+  def load(filename : Path | String = ".env", override_keys : Bool = false) : Hash(String, String)
     hash = Hash(String, String).new
     File.each_line filename do |line|
       handle_line line, hash
     end
-    load hash, skip_duplicate_keys
+    load hash, override_keys
   end
 
   # Loads environment variables from an `IO` into the `ENV` constant.
@@ -155,12 +155,12 @@ module Dotenv
   # hash = Dotenv.load IO::Memory.new("VAR=Hello")
   # hash # => {"VAR" => "Hello"}
   # ```
-  def load(io : IO, skip_duplicate_keys : Bool = true) : Hash(String, String)
+  def load(io : IO, override_keys : Bool = false) : Hash(String, String)
     hash = Hash(String, String).new
     io.each_line do |line|
       handle_line line, hash
     end
-    load hash, skip_duplicate_keys
+    load hash, override_keys
   end
 
   # Loads a Hash of environment variables into the `ENV` constant.
@@ -170,9 +170,9 @@ module Dotenv
   #
   # Dotenv.load({"VAR" => "test"})
   # ```
-  def load(hash : Hash(String, String), skip_duplicate_keys : Bool = true) : Hash(String, String)
+  def load(hash : Hash(String, String), override_keys : Bool = false) : Hash(String, String)
     hash.each do |key, value|
-      unless ENV.has_key?(key) && skip_duplicate_keys
+      unless ENV.has_key?(key) && !override_keys
         ENV[key] = value
       end
     end

--- a/src/dotenv.cr
+++ b/src/dotenv.cr
@@ -6,7 +6,6 @@ module Dotenv
 
   # Raises an exception on parsing error.
   class_property strict : Bool = true
-  class_property skip_duplicate_keys : Bool = true
 
   @[Flags]
   private enum Quotes
@@ -107,12 +106,12 @@ module Dotenv
   # hash = Dotenv.load_string "VAR=Hello"
   # hash # => {"VAR" => "Hello"}
   # ```
-  def load_string(env_vars : String) : Hash(String, String)
+  def load_string(env_vars : String, skip_duplicate_keys : Bool = true) : Hash(String, String)
     hash = Hash(String, String).new
     env_vars.each_line do |line|
       handle_line line, hash
     end
-    load hash
+    load hash, skip_duplicate_keys
   end
 
   # Loads environment variables from a file into the `ENV` constant
@@ -125,9 +124,9 @@ module Dotenv
   # Dotenv.load? ".env-file"    # => {"VAR" => "Hello"}
   # Dotenv.load? ".not-present" # => nil
   # ```
-  def load?(filename : Path | String = ".env") : Hash(String, String)?
+  def load?(filename : Path | String = ".env", skip_duplicate_keys : Bool = true) : Hash(String, String)?
     if File.exists?(filename) || File.symlink?(filename)
-      load filename
+      load filename, skip_duplicate_keys
     end
   end
 
@@ -140,12 +139,12 @@ module Dotenv
   # Dotenv.load ".env-file"    # => {"VAR" => "Hello"}
   # Dotenv.load ".absent-file" # => No such file or directory (Errno)
   # ```
-  def load(filename : Path | String = ".env") : Hash(String, String)
+  def load(filename : Path | String = ".env", skip_duplicate_keys : Bool = true) : Hash(String, String)
     hash = Hash(String, String).new
     File.each_line filename do |line|
       handle_line line, hash
     end
-    load hash
+    load hash, skip_duplicate_keys
   end
 
   # Loads environment variables from an `IO` into the `ENV` constant.
@@ -156,12 +155,12 @@ module Dotenv
   # hash = Dotenv.load IO::Memory.new("VAR=Hello")
   # hash # => {"VAR" => "Hello"}
   # ```
-  def load(io : IO) : Hash(String, String)
+  def load(io : IO, skip_duplicate_keys : Bool = true) : Hash(String, String)
     hash = Hash(String, String).new
     io.each_line do |line|
       handle_line line, hash
     end
-    load hash
+    load hash, skip_duplicate_keys
   end
 
   # Loads a Hash of environment variables into the `ENV` constant.
@@ -171,71 +170,12 @@ module Dotenv
   #
   # Dotenv.load({"VAR" => "test"})
   # ```
-  def load(hash : Hash(String, String)) : Hash(String, String)
+  def load(hash : Hash(String, String), skip_duplicate_keys : Bool = true) : Hash(String, String)
     hash.each do |key, value|
       unless ENV.has_key?(key) && skip_duplicate_keys
         ENV[key] = value
       end
     end
-    hash
-  end
-
-  # Allows for overriding existing `ENV` keys. See `load`.
-  #
-  # ```
-  # require "dotenv"
-  #
-  # Dotenv.load ".env"       # => {"VAR" => "Hello"}
-  # Dotenv.load! ".env.test" # => {"VAR" => "World"}
-  # ```
-  def load!(filename : Path | String = ".env") : Hash(String, String)
-    load_with_temp_override do
-      load filename
-    end
-  end
-
-  # Allows for overriding existing `ENV` keys. See `load`.
-  #
-  # ```
-  # require "dotenv"
-  #
-  # Dotenv.load IO::Memory.new("VAR=Hello")  # => {"VAR" => "Hello"}
-  # Dotenv.load! IO::Memory.new("VAR=World") # => {"VAR" => "World"}
-  # ```
-  def load!(io : IO) : Hash(String, String)
-    load_with_temp_override do
-      load io
-    end
-  end
-
-  # Allows for overriding existing `ENV` keys. See `load`.
-  #
-  # ```
-  # require "dotenv"
-  #
-  # Dotenv.load({"VAR" => "Hello"})  # => ENV["VAR"] == "Hello"
-  # Dotenv.load!({"VAR" => "World"}) # => ENV["VAR"] == "World"
-  # ```
-  def load!(hash : Hash(String, String)) : Hash(String, String)
-    load_with_temp_override do
-      load hash
-    end
-  end
-
-  # Allows duplicate `ENV` keys to be overriden. Lock is placed back
-  # on after block finshes. returns the loaded env keys.
-  #
-  # ```
-  # require "dotenv"
-  #
-  # Dotenv.load_with_temp_override do
-  #   Dotenv.load({"VAR" => "test"})
-  # end
-  # ```
-  def load_with_temp_override : Hash(String, String)
-    self.skip_duplicate_keys = false
-    hash = yield
-    self.skip_duplicate_keys = true
     hash
   end
 end


### PR DESCRIPTION
Followup of https://github.com/gdotdesign/cr-dotenv/pull/20.
The reasons for this changes are:
- the `load!` methods extends the API unnecessarily, and duplicates the former `load_with_temp_override` method.
- `load!` was a previous, [now removed method in the past](https://github.com/gdotdesign/cr-dotenv/pull/16), which can add confusion.
-  there are no such equivalent for `load?`
- using a global class property changed the behavior for all `Dotenv.load` invocations, which is can yield to unwanted behaviors

Finally, if you really want, we can keep having the `load!` methods, if you prefer over `load ..., false`. They would very be just single line method. In any way, `load_with_temp_override` is now redundant, by having now the optional `skip_duplicate_keys` argument.