### PR TITLE
Update shards to crystal 1.0.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,6 @@
 name: dotenv
 version: 0.7.0
-
+crystal: ">= 0.34.0, < 2.0.0"
 authors:
   - Gusztáv Szikszai <guszti5@hotmail.com>
 


### PR DESCRIPTION
update to allow error less install on crystal 1.0.0. Currently errors out due to major version change on shards install.

there also should be a new version release as well.