### PR TITLE
Fix comment handling

### DIFF
--- a/spec/dotenv_spec.cr
+++ b/spec/dotenv_spec.cr
@@ -117,7 +117,7 @@ describe Dotenv do
       hash.should eq({"VAR" => "Dude"})
     end
 
-    it "ingores empty lines" do
+    it "ignores empty lines" do
       hash = Dotenv.load_string <<-DOTENV
 
       VAR=Dude

--- a/spec/dotenv_spec.cr
+++ b/spec/dotenv_spec.cr
@@ -117,6 +117,19 @@ describe Dotenv do
       hash.should eq({"VAR" => "Dude"})
     end
 
+    it "treats hash as comment in unquoted values" do
+      hash = Dotenv.load_string "KEY=value # this is a comment"
+      hash["KEY"].should eq "value"
+    end
+
+    it "preserves hash in quoted values" do
+      hash = Dotenv.load_string "KEY='value # not a comment'"
+      hash["KEY"].should eq "value # not a comment"
+      
+      hash = Dotenv.load_string %(KEY="value # not a comment")
+      hash["KEY"].should eq "value # not a comment"
+    end
+
     it "ignores empty lines" do
       hash = Dotenv.load_string <<-DOTENV
 

--- a/src/parser.cr
+++ b/src/parser.cr
@@ -48,7 +48,7 @@ module Dotenv
         else                 next_char
         end
       end
-      next_char
+      next_char if @current_char != '\0'
     end
 
     private def parse_key : String?
@@ -140,8 +140,6 @@ module Dotenv
             end
           when '#'
             if quotes.none?
-              str << @current_char
-            elsif last_whitespace
               skip_comment
               break
             else


### PR DESCRIPTION
## Expected Behavior

In unquoted values, `#` should mark the beginning of a comment.
Example: `KEY=value # comment` → `KEY` should be `value`

## Actual Behavior

`#` is treated as part of the value when unquoted.
Example: `KEY=value # comment` → `KEY` is `value # comment`